### PR TITLE
Fix for full PHP 7.0 downgrade

### DIFF
--- a/src/ZeroBounce.php
+++ b/src/ZeroBounce.php
@@ -35,8 +35,9 @@ class ZeroBounce
 
     }
 
-    private const ApiBaseUrl = "https://api.zerobounce.net/v2";
-    private const BulkApiBaseUrl = "https://bulkapi.zerobounce.net/v2";
+    const ApiBaseUrl = "https://api.zerobounce.net/v2";
+    const BulkApiBaseUrl = "https://bulkapi.zerobounce.net/v2";
+    
     private $apiKey = null;
 
     /**


### PR DESCRIPTION
private const properties are only available from php 7.1 upwards