### PR TITLE
Fix deprecation

### DIFF
--- a/src/ZeroBounce.php
+++ b/src/ZeroBounce.php
@@ -586,7 +586,10 @@ class ZeroBounce
             throw new ZBException('No response');
         }
         $headers = array();
-        if (isset($http_response_header) && is_array($http_response_header)) {
+        if (function_exists('http_get_last_response_headers')) {
+            // @see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_http_response_header_predefined_variable
+            $headers = http_get_last_response_headers();
+        } elseif (isset($http_response_header) && is_array($http_response_header)) {
             $headers = $http_response_header;
         }
         return array('body' => $body, 'headers' => $headers);


### PR DESCRIPTION
Hi @franciscbalint,

The latest changes re-introduce a new PHP 8.5 deprecation which was already fixed.
https://github.com/zerobounce/zero-bounce-php-sdk-setup/pull/27

I copied the fix.