### PR TITLE
Fix PHP 8.5 deprecation

### DIFF
--- a/src/ZeroBounce.php
+++ b/src/ZeroBounce.php
@@ -588,9 +588,9 @@ class ZeroBounce
         $headers = array();
         if (function_exists('http_get_last_response_headers')) {
             // @see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_http_response_header_predefined_variable
-            $fromFn = http_get_last_response_headers();
-            if (is_array($fromFn)) {
-                $headers = $fromFn;
+            $http_response_header = http_get_last_response_headers();
+            if (is_array($http_response_header)) {
+                $headers = $http_response_header;
             }
         } elseif (isset($http_response_header) && is_array($http_response_header)) {
             $headers = $http_response_header;


### PR DESCRIPTION
Hi @franciscbalint,

I'm sorry, seems like my previous PR didn't correctly fix the deprecation.
I could reproduce locally (thanks to your unit test) on PHP 8.5 and I can confirm it's fixed with this new PR.

Seems like I had to name the result of `http_get_last_response_headers` with the same name `$http_response_header` in order to fix the deprecation. (cf https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_http_response_header_predefined_variable)

Even if the use of `http_response_header` was in a skip condition (elseif) it was still parsed by PHP and reported as a deprecation. 